### PR TITLE
design: 기본 컬러셋 추가

### DIFF
--- a/LeaveGo/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/LeaveGo/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,6 +1,23 @@
 {
   "colors" : [
     {
+      "color" : {
+        "platform" : "universal",
+        "reference" : "labelColor"
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "platform" : "universal",
+        "reference" : "labelColor"
+      },
       "idiom" : "universal"
     }
   ],

--- a/LeaveGo/Assets.xcassets/BorderColor.colorset/Contents.json
+++ b/LeaveGo/Assets.xcassets/BorderColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "225",
+          "green" : "225",
+          "red" : "225"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "58",
+          "green" : "58",
+          "red" : "58"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/LeaveGo/Assets.xcassets/CustomBackgroundColor.colorset/Contents.json
+++ b/LeaveGo/Assets.xcassets/CustomBackgroundColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "252",
+          "green" : "252",
+          "red" : "252"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "51",
+          "green" : "51",
+          "red" : "51"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/LeaveGo/Assets.xcassets/CustomLabelColor.colorset/Contents.json
+++ b/LeaveGo/Assets.xcassets/CustomLabelColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "34",
+          "green" : "34",
+          "red" : "34"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "234",
+          "green" : "234",
+          "red" : "234"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/LeaveGo/Assets.xcassets/SecandaryColor.colorset/Contents.json
+++ b/LeaveGo/Assets.xcassets/SecandaryColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "102",
+          "green" : "102",
+          "red" : "102"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "170",
+          "green" : "170",
+          "red" : "170"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
기본 컬러셋과 사용 용도를 정리했습니다.
메인에 머지가 되면 풀 받으신 후, 각자 맡고 계신 화면에서 해당되는 UI들이 있다면 알맞은 색상으로 지정해주세요.
나중에 컨셉 색상이 정해지면 컬러셋만 수정해서 한 번에 적용하려고 합니다.