### PR TITLE
fix: 온보딩 닉네임 입력 버튼 기본 비활성화

### DIFF
--- a/LeaveGo.xcodeproj/project.pbxproj
+++ b/LeaveGo.xcodeproj/project.pbxproj
@@ -148,7 +148,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = GHGPAZGBBT;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = LeaveGo/Info.plist;
 				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "사용자 위치에 접근을 위해 권한이 필요합니다.";

--- a/LeaveGo/Feature/Onboarding/NicknameInputViewController.swift
+++ b/LeaveGo/Feature/Onboarding/NicknameInputViewController.swift
@@ -50,6 +50,7 @@ class NicknameInputViewController: UIViewController {
         case .onboarding:
             nicknameTextField.text = ""
             nicknameTextField.placeholder = "닉네임을 입력해주세요"
+            saveButton.isEnabled = false
         case .editing:
             if let nickname = UserSetting.shared.nickname, !nickname.isEmpty {
                 nicknameTextField.text = nickname


### PR DESCRIPTION
### ✅ 변경사항

- 온보딩 뷰 닉네임 입력화면 텍스트 입력안해도 활성화 되어있는 문제 수정

---

### 🧪 테스트시 유의 사항

- 삭제 후 실행해서 테스트해주세요!

---

### 📝 참고

- 

---

### 💜 결과

- 온보딩뷰 닉네임 버튼 비활성화 체크 해주시면 됩니다
