### PR TITLE
장소 - 지도로보기 클러스터링 작업

### DIFF
--- a/LeaveGo.xcodeproj/project.pbxproj
+++ b/LeaveGo.xcodeproj/project.pbxproj
@@ -148,10 +148,8 @@
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = LeaveGo/Info.plist;
-				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "사용자 위치에 접근을 위해 권한이 필요합니다.";
-				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "사용자 위치에 접근을 위해 권한이 필요합니다2";
+				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "사용자 위치에 접근을 위해 권한이 필요합니다.";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "사용자 위치에 접근을 위해 권한이 필요합니다.";
-				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "사진앨범에 접근하도록 허용버튼을 눌러주세요.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
@@ -180,15 +178,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = LeaveGo/Info.plist;
-				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "사용자 위치에 접근을 위해 권한이 필요합니다.";
-				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "사용자 위치에 접근을 위해 권한이 필요합니다2";
+				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "사용자 위치에 접근을 위해 권한이 필요합니다.";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "사용자 위치에 접근을 위해 권한이 필요합니다.";
-				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "사진앨범에 접근하도록 허용버튼을 눌러주세요.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
@@ -202,6 +199,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.leavego.LeaveGo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/LeaveGo/Feature/Places/Component/PlaceAnnotationView.swift
+++ b/LeaveGo/Feature/Places/Component/PlaceAnnotationView.swift
@@ -8,91 +8,101 @@
 import MapKit
 
 final class PlaceAnnotationView: MKAnnotationView {
-    
-    static let identifier: String = "PlaceAnnotationView"
-    
-    private let imageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.contentMode = .scaleAspectFill
-        imageView.clipsToBounds = true
-        imageView.layer.borderWidth = 2
-        imageView.layer.borderColor = UIColor.white.cgColor
-        imageView.backgroundColor = .white
-        return imageView
-    }()
-    
-    let titleLabel: UILabel = {
-        let label = UILabel()
-        label.font = .systemFont(ofSize: 12, weight: .black)
-        label.textColor = .label
-        label.backgroundColor = .clear
-        label.textAlignment = .center
-        return label
-    }()
-    
-    override init(annotation: MKAnnotation?, reuseIdentifier: String?) {
-        super.init(annotation: annotation, reuseIdentifier: reuseIdentifier)
-        
-        frame = CGRect(x: 0, y: 0, width: 40, height: 60)
-        configureSubviews()
-    }
-    
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        imageView.layer.cornerRadius = imageView.frame.width / 2
-    }
-    
-    func configure(with annotation: PlaceAnnotationModel) {
-        titleLabel.text = annotation.title
-        
-        // 클러스터링 식별자 설정
-        // clusteringIdentifier = "\(annotation.areaCode ?? "1")-\(annotation.cat1 ?? "1")"
-        
-        if let thumbnailImage = annotation.thumbnailImage {
-            imageView.image = thumbnailImage
-        } else {
-            // 기본 이미지 설정
-            let size = CGSize(width: 40, height: 40)
-            UIGraphicsBeginImageContext(size)
-            
-            if let image = UIImage(systemName: "pin.circle.fill") {
-                image.draw(in: CGRect(x: 0, y: 0, width: size.width, height: size.height))
-                if let resizedImage = UIGraphicsGetImageFromCurrentImageContext() {
-                    imageView.image = resizedImage
-                }
-            }
-            
-            UIGraphicsEndImageContext()
-        }
-    }
+	static let identifier: String = "PlaceAnnotationView"
+	static let clusterIdentifier: String = "placeCluster"
+	
+	private let imageView: UIImageView = {
+		let imageView = UIImageView()
+		imageView.contentMode = .scaleAspectFill
+		imageView.clipsToBounds = true
+		imageView.layer.borderWidth = 2
+		imageView.layer.borderColor = UIColor.white.cgColor
+		imageView.backgroundColor = .white
+		return imageView
+	}()
+	
+	let titleLabel: UILabel = {
+		let label = UILabel()
+		label.font = .systemFont(ofSize: 12, weight: .black)
+		label.textColor = .label
+
+		label.adjustsFontSizeToFitWidth = true
+		label.minimumScaleFactor = 0.7
+		label.lineBreakMode = .byClipping
+		return label
+	}()
+	
+	override init(annotation: MKAnnotation?, reuseIdentifier: String?) {
+		super.init(annotation: annotation, reuseIdentifier: reuseIdentifier)
+		frame = CGRect(x: 0, y: 0, width: 64, height: 64)
+
+		configureSubviews()
+	}
+	
+	required init?(coder aDecoder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+	
+	override func layoutSubviews() {
+		super.layoutSubviews()
+		imageView.frame = CGRect(x: 0, y: 0, width: 50, height: 50)
+		imageView.layer.cornerRadius = 25
+		
+		let spacing: CGFloat = 4
+
+		titleLabel.frame = CGRect(
+			x: 0,
+			y: imageView.frame.maxY + spacing,
+			width: bounds.width,
+			height: 14
+		)
+	}
+	
+	func configure(with annotation: PlaceAnnotationModel) {
+		titleLabel.text = annotation.title
+		
+		clusteringIdentifier = Self.clusterIdentifier
+		
+		if let thumbnailImage = annotation.thumbnailImage {
+			imageView.image = thumbnailImage
+		} else {
+			let size = CGSize(width: 40, height: 40)
+			UIGraphicsBeginImageContext(size)
+			
+			if let image = UIImage(systemName: "pin.circle.fill") {
+				image.draw(in: CGRect(x: 0, y: 0, width: size.width, height: size.height))
+				if let resizedImage = UIGraphicsGetImageFromCurrentImageContext() {
+					imageView.image = resizedImage
+				}
+			}
+			
+			UIGraphicsEndImageContext()
+		}
+	}
 }
 
 // MARK: LayoutSupport
 extension PlaceAnnotationView: LayoutSupport {
-    
-    func addSubviews() {
-        addSubview(imageView)
-        addSubview(titleLabel)
-    }
-    
-    func setupSubviewsConstraints() {
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        titleLabel.translatesAutoresizingMaskIntoConstraints = false
-        
-        NSLayoutConstraint.activate([
-            imageView.topAnchor.constraint(equalTo: topAnchor),
-            imageView.centerXAnchor.constraint(equalTo: centerXAnchor),
-            imageView.widthAnchor.constraint(equalToConstant: 40),
-            imageView.heightAnchor.constraint(equalToConstant: 40),
-            
-            titleLabel.topAnchor.constraint(equalTo: imageView.bottomAnchor),
-            titleLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
-            titleLabel.heightAnchor.constraint(equalToConstant: 20),
-            titleLabel.bottomAnchor.constraint(equalTo: bottomAnchor)
-        ])
-    }
+	
+	func addSubviews() {
+		addSubview(imageView)
+		addSubview(titleLabel)
+	}
+	
+	func setupSubviewsConstraints() {
+		imageView.translatesAutoresizingMaskIntoConstraints = false
+		titleLabel.translatesAutoresizingMaskIntoConstraints = false
+		
+		NSLayoutConstraint.activate([
+			imageView.topAnchor.constraint(equalTo: topAnchor),
+			imageView.centerXAnchor.constraint(equalTo: centerXAnchor),
+			imageView.widthAnchor.constraint(equalToConstant: 40),
+			imageView.heightAnchor.constraint(equalToConstant: 40),
+			
+			titleLabel.topAnchor.constraint(equalTo: imageView.bottomAnchor),
+			titleLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+			titleLabel.heightAnchor.constraint(equalToConstant: 20),
+			titleLabel.bottomAnchor.constraint(equalTo: bottomAnchor)
+		])
+	}
 }

--- a/LeaveGo/Feature/Places/Component/PlaceClusterAnnotationView.swift
+++ b/LeaveGo/Feature/Places/Component/PlaceClusterAnnotationView.swift
@@ -2,72 +2,111 @@
 //  PlaceClusterAnnotationView.swift
 //  LeaveGo
 //
-//  Created by 이치훈 on 6/16/25.
+//  Created by Seohyun Kim on 6/17/25.
 //
 
 import MapKit
 
 final class PlaceClusterAnnotationView: MKAnnotationView {
-    static let identifier = MKMapViewDefaultClusterAnnotationViewReuseIdentifier
-    
-    private let emojiLabel: UILabel = {
-        let label = UILabel()
-        label.font = .systemFont(ofSize: 20)
-        label.textAlignment = .center
-        label.textColor = .label
-        return label
-    }()
-    
-    override init(annotation: MKAnnotation?, reuseIdentifier: String?) {
-        super.init(annotation: annotation, reuseIdentifier: reuseIdentifier)
-        
-        configureUI()
-    }
-    
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    private func configureUI() {
-        frame = CGRect(x: 0, y: 0, width: 30, height: 30)
-        layer.cornerRadius = frame.height / 2
-        backgroundColor = .white // 기본 배경
-        
-        layer.borderColor = UIColor.systemBlue.cgColor
-        layer.borderWidth = 2
-        
-        addSubview(emojiLabel)
-        
-        emojiLabel.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            emojiLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
-            emojiLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
-            emojiLabel.widthAnchor.constraint(equalTo: widthAnchor),
-            emojiLabel.heightAnchor.constraint(equalTo: heightAnchor)
-        ])
- 
-    }
-    
-    func configure(with cat1: String?, count: Int) {
-        emojiLabel.text = emoji(for: cat1)
-    }
-    
-    private func emoji(for cat1: String?) -> String {
-        switch cat1 {
-        case "A01": return "🌿" // 자연
-        case "A02": return "🎨" // 예술
-        case "A03": return "🏄‍♂️" // 레포츠
-        case "A04": return "🛍️" // 쇼핑
-        case "A05": return "🍜" // 음식
-        case "A06": return "🏨" // 숙박
-        case "A07": return "🚅" // 교통
-        case "A08": return "🗺️" // 여행사
-        case "A09": return "🎆" // 축제
-        case "A10": return "🏸" // 레저스포츠
-        case "B01": return "⛩️" // 관광지
-        case "C01": return "🏛️" // 문화시설
-        default: return "📍"
-        }
-    }
+	static let identifier = MKMapViewDefaultClusterAnnotationViewReuseIdentifier
+	
+	// MARK: - Subviews
+	private let circleView: UIView = {
+		let v = UIView()
+		v.backgroundColor = .systemPink
+		v.layer.borderColor = UIColor.white.cgColor
+		v.layer.borderWidth = 2
+		return v
+	}()
+	private let symbolView: UIImageView = {
+		let iv = UIImageView()
+		iv.tintColor = .white
+		iv.contentMode = .scaleAspectFit
+		return iv
+	}()
+	private let countLabel: UILabel = {
+		let lbl = UILabel()
+		lbl.font = .boldSystemFont(ofSize: 12)
+		lbl.textColor = .black
+		lbl.textAlignment = .center
+		// 흰색 stroke
+		lbl.attributedText = NSAttributedString(string: "0", attributes: [
+			.strokeColor: UIColor.white,
+			.strokeWidth: 1
+		])
+		return lbl
+	}()
+	
+	// MARK: - Init
+	override init(annotation: MKAnnotation?, reuseIdentifier: String?) {
+		super.init(annotation: annotation, reuseIdentifier: reuseIdentifier)
+		setupUI()
+	}
+	required init?(coder: NSCoder) { fatalError() }
+	
+	// MARK: - Layout
+	private func setupUI() {
+		let diameter: CGFloat = 30
+		let labelHeight: CGFloat = 14
+		let spacing: CGFloat = 8
+		frame = CGRect(x: 0, y: 0, width: diameter, height: diameter + spacing + labelHeight)
+
+		circleView.frame = CGRect(x: 0, y: 0, width: diameter, height: diameter)
+		circleView.layer.cornerRadius = diameter / 2
+		circleView.center.x = bounds.midX
+		addSubview(circleView)
+
+		symbolView.frame = circleView.bounds.insetBy(dx: diameter * 0.1,
+													 dy: diameter * 0.1)
+		symbolView.center = CGPoint(x: diameter/2, y: diameter/2)
+		circleView.addSubview(symbolView)
+
+		countLabel.frame = CGRect(
+			x: 0,
+			y: diameter + spacing,
+			width: diameter,
+			height: labelHeight
+		)
+		addSubview(countLabel)
+	}
+	
+	override func layoutSubviews() {
+		super.layoutSubviews()
+	}
+	
+	// MARK: - Configure
+	func configure(with cat1: String?, count: Int) {
+
+		let name = sfSymbolName(for: cat1)
+		symbolView.image = UIImage(systemName: name)
+
+		let text = "\(count)"
+		let attrs: [NSAttributedString.Key: Any] = [
+			.font: UIFont.boldSystemFont(ofSize: 12),
+			.foregroundColor: UIColor.black,
+			.strokeColor: UIColor.white,
+			.strokeWidth: -2.0
+		]
+		countLabel.attributedText = NSAttributedString(string: text, attributes: attrs)
+	}
+	
+	// MARK: - SF Symbol Mapping
+	private func sfSymbolName(for cat1: String?) -> String {
+		switch cat1 {
+		case "A01": return "leaf.fill"
+		case "A02": return "paintpalette.fill"
+		case "A03": return "figure.wave"
+		case "A04": return "bag.fill"
+		case "A05": return "fork.knife"
+		case "A06": return "bed.double.fill"
+		case "A07": return "tram.fill"
+		case "A08": return "location.viewfinder"
+		case "A09": return "sparkles"
+		case "A10": return "sportscourt.fill"
+		case "B01": return "building.columns.fill"
+		case "C01": return "museum.fill"
+		default:    return "mappin.circle.fill"
+		}
+	}
 }
 


### PR DESCRIPTION
### ✅ 변경사항
- 기존에 MapViewController 위에 있던 bottomSheetView 사용안해서 제거 및 주석처리
-  클러스터링 기준: cat01(대분류) 기준으로  emoji 에서 sfsymbols로 변경
-  클러스터링 아래 임시 count label 달았음 -> 차후 cat01의 name으로 변경할 예정

---

### 🧪 테스트시 유의 사항

- 디바이스에서는 공공데이터 API에서 내려주는 주변 장소 개수에 따라 클러스터링 될 마커핀이 없을 수도 있음.

---

### 📝 참고

- 앱 빌드하고 런타임시 현 위치 사용자값을 simulator에서 custom Location에서 좌표값 한번더 받으셔야 합니다.
- 디바이스에서는 어떻게 나오는지 확인해주시면 감사할 것 같습니다.

---

### 💜 결과
| 줌아웃 초기         | 줌 아웃 더 당겼을 때  | 추가 스크린샷                           |
|:-----------------------------------------:|:----------------------------------------:|:---------------------------------------:|
| <img src="https://github.com/user-attachments/assets/f3e6436e-2626-49a5-8e6f-451557981100" width="390" alt="GitHub PR Screenshot" /> | <img src="https://github.com/user-attachments/assets/fb08c80e-bf45-419f-91b4-9269578de582" width="390" alt="iPhone Simulator Screenshot" /> | <img src="https://github.com/user-attachments/assets/8588dc6a-d34b-4b8d-b559-47daeb0ee72d" width="390" alt="Additional Screenshot" /> |

-

