### PR TITLE
커스텀 바텀시트 - 경로찾기 화면으로 이동하게 설정

### DIFF
--- a/LeaveGo/Feature/Places/RoutePlaces/mapService/RouteMapManager.swift
+++ b/LeaveGo/Feature/Places/RoutePlaces/mapService/RouteMapManager.swift
@@ -105,26 +105,6 @@ final class RouteMapManager: NSObject {
 		)
 		mapView.setVisibleMapRect(rect, edgePadding: insets, animated: true)
 	}
-
-	   // 예시로 padding을 뷰 컨트롤러에서 구해야할때
-	/*
-	   func drawRoute(_ route: MKRoute? = nil,
-					  edgePadding pad: UIEdgeInsets) {
-		   // 동일하게 1–3)번 수행 후:
-		   let poly: MKPolyline = {
-			   if let r = route { return r.polyline }
-			   guard let start = startPlacemark else { fatalError() }
-			   let c = [start.coordinate, destination.coordinate]
-			   return MKPolyline(coordinates: c, count: c.count)
-		   }()
-
-		   mapView.removeOverlays(mapView.overlays)
-		   mapView.addOverlay(poly)
-		   mapView.setVisibleMapRect(poly.boundingMapRect,
-									 edgePadding: pad,
-									 animated: true)
-	   }
-	*/
 }
 
 extension RouteMapManager: MKMapViewDelegate {

--- a/LeaveGo/Feature/Planner/PlaceDetailModalViewController.swift
+++ b/LeaveGo/Feature/Planner/PlaceDetailModalViewController.swift
@@ -37,7 +37,24 @@ class PlaceDetailModalViewController: UIViewController {
         label.numberOfLines = 0
         return label
     }()
-    
+	
+	
+	/// 경로 찾기 버튼 액션 - 경로 탐색 뷰로 이동
+	/// - Parameter sender: UIButton 클릭시 목적지 데이터를 담아 showRouteScreen에 전달
+	@IBAction func findRouteTapped(_ sender: UIButton) {
+		guard let place = place else { return }
+		let dest = RouteDestination(place: place)
+		
+		guard let presenter = presentingViewController else {
+			print("⚠️ presentingViewController가 없습니다")
+			return
+		}
+		
+		dismiss(animated: true) {
+			presenter.showRouteScreen(destination: dest)
+		}
+	}
+	
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         blurEffectView.applyFeatherMask(to: blurEffectView)
@@ -45,7 +62,7 @@ class PlaceDetailModalViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         activityIndicator.hidesWhenStopped = true
         activityIndicator.startAnimating()
         

--- a/LeaveGo/Feature/Planner/Planner.storyboard
+++ b/LeaveGo/Feature/Planner/Planner.storyboard
@@ -326,6 +326,7 @@
                                     <color key="baseForegroundColor" name="CustomBackgroundColor"/>
                                 </buttonConfiguration>
                                 <connections>
+                                    <action selector="findRouteTapped:" destination="5eA-BR-KNV" eventType="touchUpInside" id="yuE-9L-mOj"/>
                                     <action selector="navigateToPlaceList:" destination="K6D-HB-F25" eventType="touchUpInside" id="HBK-Wl-ayK"/>
                                 </connections>
                             </button>

--- a/LeaveGo/Shared/Extension/UIViewController+RouteHelper.swift
+++ b/LeaveGo/Shared/Extension/UIViewController+RouteHelper.swift
@@ -1,0 +1,58 @@
+//
+//  UIViewController+RouteHelper.swift
+//  LeaveGo
+//
+//  Created by Seohyun Kim on 6/18/25.
+//
+import UIKit
+import MapKit
+
+/// UIViewController + RouteHelper
+///  - 목적지 데이터를 가지고 경로 찾는 화면으로 이동할 수 있게 구현한 헬퍼 함수입니다.
+extension UIViewController {
+	func showRouteScreen(
+		destination: RouteDestination,
+		animated: Bool = true
+	) {
+		// 1) PlaceRouteVC 인스턴스화
+		let sb = UIStoryboard(name: "PlaceRoute", bundle: nil)
+		guard let routeVC = sb.instantiateViewController(identifier: "PlaceRoute")
+				as? PlaceRouteViewController else {
+			print("'PlaceRoute' 스토리보드 ID 확인 필요")
+			return
+		}
+		routeVC.destination = destination
+		
+		// 2) 푸시할 네비게이션 컨트롤러 찾기
+		let hostNav: UINavigationController? = {
+			// # CASE 1. 현재 VC가 네비게이션 안에 있는 경우
+			if let nav = self.navigationController { return nav }
+			
+			// # CASE 2. present한 VC(presenter)가 네비게이션 안에 있는 경우
+			if let presNav = self.presentingViewController?.navigationController {
+				return presNav
+			}
+			
+			// # CASE 3. presenter가 TabBarController 라면, 그 선택된 VC가 네비일수도 있음
+			if let tab = self.presentingViewController as? UITabBarController,
+			   let selectNav = tab.selectedViewController as? UINavigationController {
+				return selectNav
+			}
+			
+			// # CASE 4. 혹은 self 인스턴스가 TabBarController 안에서 호출된 경우
+			if let tab = self as? UITabBarController,
+			   let selNav = tab.selectedViewController as? UINavigationController {
+				return selNav
+			}
+			
+			return nil
+		}()
+		
+		// 3) 찾아서 푸시
+		if let nav = hostNav {
+			nav.pushViewController(routeVC, animated: animated)
+		} else {
+			assertionFailure("showRouteScreen: 푸시할 네비게이션 컨트롤러가 없습니다.")
+		}
+	}
+}


### PR DESCRIPTION
### ✅ 변경사항

- PlacesVC 테이블 셀 클릭 - 디테일 뷰 바텀시트의 경로 찾기 버튼 누르면 경로 이동 되어야함.
- Planner스토리보드:  DetailModalVC에 findRouteTapped 액션 추가

---

### 🧪 테스트시 유의 사항

- morebutton의 경로찾기 경로 찾아지는지 테스트 부탁드려요
- 테이블 셀 디테일 뷰 바텀시트 경로 찾기 찾아지는지 확인해주세요. 

### 💜 결과
| 테이블셀 디테일뷰 이동     |  경로 찾기 버튼 누르면 이동  | 
|:-----------------------------------------:|:----------------------------------------:|
| <img src="https://github.com/user-attachments/assets/12bb3a1e-4b49-4e84-ad3d-e7ad3c17f9da" width="390" alt="GitHub PR Screenshot" /> | <img src="https://github.com/user-attachments/assets/93350c04-73ab-4301-bffd-2f553a0fa6e8" width="390" alt="iPhone Simulator Screenshot" /> |