### PR TITLE
어노테이션 이미지 클릭시 디테일 바텀시트 뷰 노출

### DIFF
--- a/LeaveGo/Feature/Places/MapViewController.swift
+++ b/LeaveGo/Feature/Places/MapViewController.swift
@@ -223,6 +223,42 @@ extension MapViewController: MKMapViewDelegate {
             mapView.setRegion(region, animated: true)
         }
     }
+	
+	/// 어노테이션 탭했을 때 호출
+	/// - Parameters:
+	///   - mapView: 어노테이션 뷰가 선택된 MKMapView 인스턴스
+	///   - view: 선택된 어노테이션 인스턴스
+	///   뷰의 `annotation`이 `PlaceAnnotationModel`인 경우에만 처리
+	func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
+		guard let annotation = view.annotation as? PlaceAnnotationModel else { return }
+		mapView.deselectAnnotation(annotation, animated: false)
+
+		if let presented = presentedViewController {
+			presented.dismiss(animated: false) { [weak self] in
+				self?.presentDetail(for: annotation)
+			}
+		} else {
+			presentDetail(for: annotation)
+		}
+	}
+	
+	private func presentDetail(for annotation: PlaceAnnotationModel) {
+		let sb = UIStoryboard(name: String(describing: Planner.self), bundle: nil)
+		guard let detailVC = sb.instantiateViewController(
+			withIdentifier: String(describing: PlaceDetailModalViewController.self)
+		) as? PlaceDetailModalViewController else {
+			return
+		}
+
+		detailVC.place = annotation.placeModel
+
+		detailVC.modalPresentationStyle = .pageSheet
+		if let sheet = detailVC.sheetPresentationController {
+			sheet.detents = [.medium(), .large()]
+		}
+		
+		present(detailVC, animated: true)
+	}
 
     func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
 		if annotation is MKUserLocation {

--- a/LeaveGo/Feature/Places/Model/PlaceAnnotationModel.swift
+++ b/LeaveGo/Feature/Places/Model/PlaceAnnotationModel.swift
@@ -8,22 +8,32 @@
 import MapKit
 
 class PlaceAnnotationModel: NSObject, MKAnnotation {
-    let coordinate: CLLocationCoordinate2D
-    let title: String?
-    let thumbnailImage: UIImage?
-    
-    let areaCode: String? // 지역코드
-    let cat1: String? // 대분류코드
-    let cat2: String? // 중분류코드
-    let cat3: String? // 소분류코드
-
-    init(coordinate: CLLocationCoordinate2D, title: String?, thumbnailImage: UIImage?, areaCode: String?, cat1: String?, cat2: String?, cat3: String?) {
-        self.coordinate = coordinate
-        self.title = title
-        self.thumbnailImage = thumbnailImage
-        self.areaCode = areaCode
-        self.cat1 = cat1
-        self.cat2 = cat2
-        self.cat3 = cat3
-    }
+	// 원본 PlaceModel 보관
+	let placeModel: PlaceModel
+	
+	// MKAnnotation 필수 프로퍼티
+	let coordinate: CLLocationCoordinate2D
+	let title: String?
+	
+	// 기타 필요한 정보
+	let thumbnailImage: UIImage?
+	let areaCode, cat1, cat2, cat3: String?
+	let contentId, contentTypeId: String
+	
+	// PlaceModel 하나로부터 초기화
+	init(place: PlaceModel) {
+		self.placeModel     = place
+		self.coordinate     = CLLocationCoordinate2D(
+			latitude: place.latitude,
+			longitude: place.longitude
+		)
+		self.title          = place.title
+		self.thumbnailImage = place.thumbnailImage
+		self.areaCode       = place.areaCode
+		self.cat1           = place.cat1
+		self.cat2           = place.cat2
+		self.cat3           = place.cat3
+		self.contentId      = place.contentId
+		self.contentTypeId  = place.contentTypeId
+	}
 }

--- a/LeaveGo/Feature/Places/Model/PlaceModel.swift
+++ b/LeaveGo/Feature/Places/Model/PlaceModel.swift
@@ -68,13 +68,7 @@ extension PlaceModel {
 
     /// MapViewContoller에서 mapview에 전달 하기위해 annotaionModel형태로 전달해야 합니다.
     func toAnnotationModel() -> PlaceAnnotationModel {
-        PlaceAnnotationModel(coordinate: CLLocationCoordinate2D(latitude: latitude, longitude: longitude),
-                             title: title,
-                             thumbnailImage: thumbnailImage,
-                             areaCode: areaCode,
-                             cat1: cat1,
-                             cat2: cat2,
-                             cat3: cat3)
+		return PlaceAnnotationModel(place: self)
     }
 }
 


### PR DESCRIPTION
### ✅ 변경사항

- `PlaceAnnotationModel` 타입을 또 따로 만들었던 형태에서 `Placemodel` 주입
- `Placemodel`에 있던 `toAnnotationModel` 메소드 수정
- MapViewController 에서 어노테이션 선택시 바텀시트 `present` 코드 추가
  - 딜리게이트 `didSelect`
  - `presentDetail` 

---

### 🧪 테스트시 유의 사항

- 어노테이션 눌렀을 때 바텀시트 올라오는거 체크 부탁드려요

---

### 📝 참고

-  아직 바텀시트 올라올 때 그 장소 안 가려지게 focus 하는거 못했어요. 따로 더 설정해야돼요.
    클러스터링 줌인 했을 때 안 풀리는 거 먼저 해결하고, 경로 찾기 버튼 액션 설정하고 이부분 살펴보겠습니다.

