### PR TITLE
fix: 여행썸네일 삭제시 기본이미지 제거

### DIFF
--- a/LeaveGo/Feature/NewTrip/PlannerEditorViewController.swift
+++ b/LeaveGo/Feature/NewTrip/PlannerEditorViewController.swift
@@ -124,7 +124,7 @@ class PlannerEditorViewController: UIViewController {
                 }
             }
 
-            tripThumbnail.image = UIImage(systemName: "photo")
+            tripThumbnail.image = nil
             isImageSelected = false
             thumbnailAdd.setTitle("이미지 추가", for: .normal)
         } else {


### PR DESCRIPTION
여행 상세 페이지 기본이미지 덮어씌어지는 부분 삭제